### PR TITLE
Add a method to access the adjacency matrix

### DIFF
--- a/src/plugins/robots/kilobot/simulator/kilobot_communication_medium.h
+++ b/src/plugins/robots/kilobot/simulator/kilobot_communication_medium.h
@@ -52,12 +52,20 @@ namespace argos {
        * @throws CARGoSException If the passed entity is not managed by this medium.
        */
       const CSet<CKilobotCommunicationEntity*>& GetKilobotsCommunicatingWith(CKilobotCommunicationEntity& c_entity) const;
-
-   private:
-
+      
       /** Defines the adjacency matrix */
       typedef std::map<CKilobotCommunicationEntity*, CSet<CKilobotCommunicationEntity*> > TAdjacencyMatrix;
-
+      
+      /**
+       * Returns a refrence to the adjacency matrix.
+       * @return A refrence to the adjacency matrix.
+       */
+      TAdjacencyMatrix& GetCommMatrix(){
+          return m_tCommMatrix;
+      }
+      
+   private:
+      
       /** The adjacency matrix, that associates each entity with the entities that communicate with it */
       TAdjacencyMatrix m_tCommMatrix;
 


### PR DESCRIPTION
Having access to the adjacency matrix allows external communication entities (created through a loop function) to communicate with the Kilobots (Example: creating an overhead controller to send special messages to the Kilobots based on their position)