### PR TITLE
Edited motion related parameters to meet reality

### DIFF
--- a/src/plugins/robots/kilobot/control_interface/ci_kilobot_controller.cpp
+++ b/src/plugins/robots/kilobot/control_interface/ci_kilobot_controller.cpp
@@ -110,8 +110,8 @@ void CCI_KilobotController::ControlStep() {
    /* Set actuator values */
    // TODO set proper conversion factors
    if(m_pcMotors) {
-      m_pcMotors->SetLinearVelocity(3.0 * m_ptRobotState->right_motor / 255.0,
-                                    3.0 * m_ptRobotState->left_motor / 255.0);
+      m_pcMotors->SetLinearVelocity(6.0 * m_ptRobotState->right_motor / 255.0,
+                                    6.0 * m_ptRobotState->left_motor / 255.0);
    }
    if(m_pcLED) {
       m_pcLED->SetColor(CColor(255 * RED(m_ptRobotState->color)   / 3,

--- a/src/plugins/robots/kilobot/control_interface/kilolib.c
+++ b/src/plugins/robots/kilobot/control_interface/kilolib.c
@@ -68,10 +68,10 @@ uint32_t mt_uniform32() {
 uint32_t kilo_ticks                = 0;   // current number of elapsed ticks
 uint16_t kilo_tx_period            = 100; // message transmission period in ms
 uint16_t kilo_uid                  = 0;
-uint8_t  kilo_turn_left            = 255;
-uint8_t  kilo_turn_right           = 255;
-uint8_t  kilo_straight_left        = 255;
-uint8_t  kilo_straight_right       = 255;
+uint8_t  kilo_turn_left            = 77;
+uint8_t  kilo_turn_right           = 77;
+uint8_t  kilo_straight_left        = 48;
+uint8_t  kilo_straight_right       = 48;
 void message_rx_dummy(message_t* m, distance_measurement_t* d) { }
 message_t *message_tx_dummy() { return NULL; }
 void message_tx_success_dummy() {}

--- a/src/plugins/robots/kilobot/simulator/dynamics2d_kilobot_model.cpp
+++ b/src/plugins/robots/kilobot/simulator/dynamics2d_kilobot_model.cpp
@@ -16,7 +16,7 @@ namespace argos {
 
    static const Real KILOBOT_MAX_FORCE  = 0.001f;
    static const Real KILOBOT_MAX_TORQUE = 0.001f;
-   static const Real KILOBOT_FRICTION   = 0.7f;
+   static const Real KILOBOT_FRICTION   = 2.5f;
 
    enum KILOBOT_WHEELS {
       KILOBOT_LEFT_WHEEL = 0,
@@ -43,7 +43,6 @@ namespace argos {
          NodeExists(*c_entity.GetConfigurationNode(), "dynamics2d")) {
          TConfigurationNode& tDyn2D = GetNode(*c_entity.GetConfigurationNode(), "dynamics2d");
          GetNodeAttributeOrDefault(tDyn2D, "friction", fFriction, fFriction);
-         DEBUG("Kilobot dynamics 2D model using friction = %f\n", fFriction);
       }
       /* Create the actual body with initial position and orientation */
       cpBody* ptBody =


### PR DESCRIPTION
The kilobot motors value and the velocity conversion factor have been set to match the average linear velocity (1cm/sec) and the average angular velocity (40°/sec) of a real kilobot.

The kilobot-kilobot friction coefficient has been changed to have a better match with reality.